### PR TITLE
Remove Rspec::Rails::FixturesSupport

### DIFF
--- a/lib/rspec/rails/configuration.rb
+++ b/lib/rspec/rails/configuration.rb
@@ -62,7 +62,7 @@ module RSpec
       config.add_setting :use_instantiated_fixtures
       config.add_setting :global_fixtures
       config.add_setting :fixture_path
-      config.include RSpec::Rails::FixtureSupport, :use_fixtures
+      # config.include RSpec::Rails::FixtureSupport, :use_fixtures
 
       # We'll need to create a deprecated module in order to properly report to
       # gems / projects which are relying on this being loaded globally.
@@ -71,7 +71,7 @@ module RSpec
       #
       # @deprecated Include `RSpec::Rails::RailsExampleGroup` or
       #   `RSpec::Rails::FixtureSupport` directly instead
-      config.include RSpec::Rails::FixtureSupport
+      # config.include RSpec::Rails::FixtureSupport
 
       # This allows us to expose `render_views` as a config option even though it
       # breaks the convention of other options by using `render_views` as a

--- a/lib/rspec/rails/example/rails_example_group.rb
+++ b/lib/rspec/rails/example/rails_example_group.rb
@@ -12,7 +12,7 @@ module RSpec
       include RSpec::Rails::MinitestLifecycleAdapter if ::Rails::VERSION::STRING >= '4'
       include RSpec::Rails::MinitestAssertionAdapter
       include RSpec::Rails::Matchers
-      include RSpec::Rails::FixtureSupport
+      # include RSpec::Rails::FixtureSupport
     end
   end
 end


### PR DESCRIPTION
We were having trouble getting rspec to run with neo4j after removing ActiveRecord due to dependencies in this gem for RSpec::Rails::FixtureSupport.  

We attempted configuring our rails_helper in several configurations and turning off fixtures to no avail.  We figured that this is the easiest way to get it working now so we can focus on migrating from PG to Neo4j.

